### PR TITLE
Clay: [MC-18] Updated code to produce new JSON timestamp properties...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
 	    <dependency>
             <groupId>com.marklogic</groupId>
             <artifactId>marklogic-client-api</artifactId>
-            <version>4.1.0</version>
+            <version>4.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.marklogic</groupId>

--- a/src/main/java/com/marklogic/mule/extension/connector/internal/operation/MarkLogicInsertionBatcher.java
+++ b/src/main/java/com/marklogic/mule/extension/connector/internal/operation/MarkLogicInsertionBatcher.java
@@ -27,6 +27,9 @@ import com.marklogic.mule.extension.connector.internal.config.MarkLogicConfigura
 import com.marklogic.mule.extension.connector.internal.connection.MarkLogicConnection;
 
 import java.io.InputStream;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -179,6 +182,18 @@ public class MarkLogicInsertionBatcher {
         JobReport jr = dmm.getJobReport(jobTicket);
         ObjectNode obj = jsonFactory.createObjectNode();
         obj.put("jobID", jobTicket.getJobId());
+        Calendar jobStartTime = jr.getJobStartTime();
+        if (jobStartTime == null) {
+            jobStartTime = Calendar.getInstance();
+        }
+        Calendar jobEndTime = jr.getJobEndTime();
+        if (jobEndTime == null) {
+            jobEndTime = Calendar.getInstance();
+        }
+        Calendar jobReportTime = jr.getReportTimestamp();
+        if (jobReportTime == null) {
+            jobReportTime = Calendar.getInstance();
+        }
         long successBatches = jr.getSuccessBatchesCount();
         long successEvents = jr.getSuccessEventsCount();
         long failBatches = jr.getFailureBatchesCount();
@@ -193,7 +208,20 @@ public class MarkLogicInsertionBatcher {
         obj.put("failedBatches", failBatches);
         obj.put("failedEvents", failEvents);
         obj.put("jobName", jobName);
+        obj.put("jobStartTime", calendarISO8601(jobStartTime));
+        obj.put("jobEndTime", calendarISO8601(jobEndTime));
+        obj.put("jobReportTime", calendarISO8601(jobReportTime));
         return obj;
+    }
+    
+    /*Formats a <code>Calendar</code> value into a ISO8601-compliant date/time string.*/
+    String calendarISO8601(Calendar calendar) {
+        //Calendar calendar = incal.getInstance();
+        Date date = calendar.getTime();
+        SimpleDateFormat sdf;
+        sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+        String text = sdf.format(date);
+        return text;
     }
 
     /**

--- a/src/test/java/com/marklogic/mule/extension/connector/MarkLogicOperationsTestCase.java
+++ b/src/test/java/com/marklogic/mule/extension/connector/MarkLogicOperationsTestCase.java
@@ -13,18 +13,23 @@
  */
 package com.marklogic.mule.extension.connector;
 
+import java.text.SimpleDateFormat;
+import java.util.GregorianCalendar;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.StringContains.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
-import static org.hamcrest.core.Is.is;
 
 import org.junit.Test;
 import org.mule.functional.junit4.MuleArtifactFunctionalTestCase;
 
-
 public class MarkLogicOperationsTestCase extends MuleArtifactFunctionalTestCase {
 
   private static final String UUID_REGEX = "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}";
+  private static final String CURRENT_DATE = new SimpleDateFormat("yyyy-MM-dd").format(new GregorianCalendar().getTime());
+  
   /**
    * Specifies the mule config xml with the flows that are going to be executed in the tests, this file lives in the test resources.
    */
@@ -60,7 +65,7 @@ public class MarkLogicOperationsTestCase extends MuleArtifactFunctionalTestCase 
             .getMessage()
             .getPayload()
             .getValue());
-    assertThat(payloadValue,notNullValue());
+    assertThat(payloadValue, notNullValue());
   }
   @Test
   public void executeGetJobReportOperation() throws Exception {
@@ -70,5 +75,8 @@ public class MarkLogicOperationsTestCase extends MuleArtifactFunctionalTestCase 
                                       .getPayload()
                                       .getValue());
     assertThat(payloadValue, startsWith("{\"importResults\":[{\"jobID\":\""));
+    assertThat(payloadValue, containsString("\"jobStartTime\":\"" + CURRENT_DATE + "T"));
+    assertThat(payloadValue, containsString("\"jobEndTime\":\"" + CURRENT_DATE + "T"));
+    assertThat(payloadValue, containsString("\"jobReportTime\":\"" + CURRENT_DATE + "T"));
   }  
 }


### PR DESCRIPTION
…on getJobReport(), and associated tests; updated to Java API 4.2.0.