### PR TITLE
First batch of code smell fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,6 @@
                         <id>test</id>
                         <phase>test</phase>
                         <goals>
-                            <!--<goal>test</goal>-->
                             <goal>coverage-report</goal>
                         </goals>
                     </execution>
@@ -168,20 +167,6 @@
             <groupId>com.marklogic</groupId>
             <artifactId>ml-javaclient-util</artifactId>
             <version>4.4.0</version>
-            <!-- <exclusions>
-                <exclusion>
-                    <groupId>com.marklogic</groupId>
-                    <artifactId>marklogic-xcc</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.springframework</groupId>
-                    <artifactId>spring-context</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jdom</groupId>
-                    <artifactId>jdom2</artifactId>
-                </exclusion>
-            </exclusions> -->
         </dependency>
         <dependency>
             <groupId>com.marklogic</groupId>

--- a/src/main/java/com/marklogic/mule/extension/connector/api/connection/AuthenticationType.java
+++ b/src/main/java/com/marklogic/mule/extension/connector/api/connection/AuthenticationType.java
@@ -13,9 +13,9 @@
  */
 package com.marklogic.mule.extension.connector.api.connection;
 
-/**
- * Created by jkrebs on 4/11/2019.
- */
+// sonarqube wants these to be uppercase, but cannot change them in the 1.x timeline since they're part of the
+// public API
+@SuppressWarnings("java:S115")
 public enum AuthenticationType
 {
     digest("digest"),

--- a/src/main/java/com/marklogic/mule/extension/connector/api/operation/MarkLogicMimeType.java
+++ b/src/main/java/com/marklogic/mule/extension/connector/api/operation/MarkLogicMimeType.java
@@ -18,51 +18,42 @@ import com.marklogic.mule.extension.connector.internal.result.resultset.*;
 import java.util.Arrays;
 import java.util.List;
 
+// sonarqube wants these to be uppercase, but cannot change them in the 1.x timeline since they're part of the
+// public API
+@SuppressWarnings("java:S115")
 public enum MarkLogicMimeType {
 
-    xml{
+    xml {
         @Override
         public MarkLogicRecordExtractor getRecordExtractor() {
-            if (xmlRecordExtractor == null) {
-                xmlRecordExtractor = new MarkLogicXMLRecordExtractor();
-            }
             return xmlRecordExtractor;
         }
     },
-    json{
+    json {
         @Override
         public MarkLogicRecordExtractor getRecordExtractor() {
-            if (jsonRecordExtractor == null) {
-                jsonRecordExtractor = new MarkLogicJSONRecordExtractor();
-            }
             return jsonRecordExtractor;
         }
     },
-    text{
+    text {
         @Override
         public MarkLogicRecordExtractor getRecordExtractor() {
-            if (textRecordExtractor == null) {
-                textRecordExtractor = new MarkLogicTextRecordExtractor();
-            }
             return textRecordExtractor;
         }
     },
-    binary{
+    binary {
         @Override
         public MarkLogicRecordExtractor getRecordExtractor() {
-            if (binaryRecordExtractor == null) {
-                binaryRecordExtractor = new MarkLogicBinaryRecordExtractor();
-            }
             return binaryRecordExtractor;
         }
 
 
     };
 
-    private static MarkLogicBinaryRecordExtractor binaryRecordExtractor;
-    private static MarkLogicXMLRecordExtractor xmlRecordExtractor;
-    private static MarkLogicJSONRecordExtractor jsonRecordExtractor;
-    private static MarkLogicTextRecordExtractor textRecordExtractor;
+    private static MarkLogicBinaryRecordExtractor binaryRecordExtractor = new MarkLogicBinaryRecordExtractor();
+    private static MarkLogicXMLRecordExtractor xmlRecordExtractor = new MarkLogicXMLRecordExtractor();
+    private static MarkLogicJSONRecordExtractor jsonRecordExtractor = new MarkLogicJSONRecordExtractor();
+    private static MarkLogicTextRecordExtractor textRecordExtractor = new MarkLogicTextRecordExtractor();
 
     public static MarkLogicMimeType fromString(String mimeString)
     {

--- a/src/main/java/com/marklogic/mule/extension/connector/api/operation/MarkLogicQueryFormat.java
+++ b/src/main/java/com/marklogic/mule/extension/connector/api/operation/MarkLogicQueryFormat.java
@@ -15,9 +15,9 @@ package com.marklogic.mule.extension.connector.api.operation;
 
 import com.marklogic.client.io.Format;
 
-/**
- * Created by credding on 4/28/2019.
- */
+// sonarqube wants these to be uppercase, but cannot change them in the 1.x timeline since they're part of the
+// public API
+@SuppressWarnings("java:S115")
 public enum MarkLogicQueryFormat
 {
     XML{

--- a/src/main/java/com/marklogic/mule/extension/connector/api/operation/MarkLogicQueryStrategy.java
+++ b/src/main/java/com/marklogic/mule/extension/connector/api/operation/MarkLogicQueryStrategy.java
@@ -19,9 +19,9 @@ import com.marklogic.client.io.StringHandle;
 import com.marklogic.client.query.*;
 import org.apache.commons.jexl3.*;
 
-/**
- * Created by jkrebs on 4/9/2019.
- */
+// sonarqube wants these to be uppercase, but cannot change them in the 1.x timeline since they're part of the
+// public API
+@SuppressWarnings("java:S115")
 public enum MarkLogicQueryStrategy
 {
     RawStructuredQueryDefinition {
@@ -35,7 +35,7 @@ public enum MarkLogicQueryStrategy
             return dmm.newQueryBatcher((RawStructuredQueryDefinition) query);
         }
     },
-    StructuredQueryBuilder{
+    StructuredQueryBuilder {
         @Override
         public QueryDefinition getQueryDefinition(QueryManager queryManager, String queryString, MarkLogicQueryFormat fmt, String optionsName) {
             return createStructuredQuery(queryManager,queryString,optionsName);

--- a/src/main/java/com/marklogic/mule/extension/connector/internal/config/MarkLogicConfiguration.java
+++ b/src/main/java/com/marklogic/mule/extension/connector/internal/config/MarkLogicConfiguration.java
@@ -152,22 +152,28 @@ public class MarkLogicConfiguration
         this.jobName = jobName;
     }
 
-    public ServerTransform generateServerTransform(String transformName, String transformParams)
+    /**
+     *
+     * @param transformName
+     * @param transformParams
+     * @return an Optional, as sonarqube was not pleased about null being returned
+     */
+    public java.util.Optional<ServerTransform> generateServerTransform(String transformName, String transformParams)
     {
         if (isDefined(transformName))
         {
             LOGGER.debug("Transforming query doc payload with operation-defined transform: {}", serverTransform);
-            return this.createServerTransform(transformName, transformParams);
+            return java.util.Optional.of(this.createServerTransform(transformName, transformParams));
         }
         else if (isDefined(this.serverTransform))
         {
             LOGGER.debug("Transforming query doc payload with connection-defined transform: {}", this.getServerTransform());
-            return createServerTransform(this.serverTransform, this.serverTransformParams);
+            return java.util.Optional.of(createServerTransform(this.serverTransform, this.serverTransformParams));
         }
         else
         {
             LOGGER.debug("Querying docs without a transform");
-            return null;
+            return java.util.Optional.empty();
         }
     }
 

--- a/src/main/java/com/marklogic/mule/extension/connector/internal/error/exception/MarkLogicConnectorException.java
+++ b/src/main/java/com/marklogic/mule/extension/connector/internal/error/exception/MarkLogicConnectorException.java
@@ -16,6 +16,9 @@ package com.marklogic.mule.extension.connector.internal.error.exception;
 import com.marklogic.mule.extension.connector.internal.error.MarkLogicConnectorSimpleErrorType;
 import org.mule.runtime.extension.api.exception.ModuleException;
 
+// sonarqube is disappointed that this has 6 parent classes instead of the max of 5, but that is due to ModuleException's
+// hierarchy and does not seem avoidable if a class needs to extend ModuleException
+@SuppressWarnings("java:S110")
 public class MarkLogicConnectorException extends ModuleException
 {
 

--- a/src/main/java/com/marklogic/mule/extension/connector/internal/error/provider/MarkLogicExecuteErrorsProvider.java
+++ b/src/main/java/com/marklogic/mule/extension/connector/internal/error/provider/MarkLogicExecuteErrorsProvider.java
@@ -14,10 +14,11 @@
 package com.marklogic.mule.extension.connector.internal.error.provider;
 
 import com.marklogic.mule.extension.connector.internal.error.MarkLogicConnectorSimpleErrorType;
-import java.util.Set;
-import java.util.HashSet;
 import org.mule.runtime.extension.api.annotation.error.ErrorTypeProvider;
 import org.mule.runtime.extension.api.error.ErrorTypeDefinition;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class MarkLogicExecuteErrorsProvider implements ErrorTypeProvider
 {
@@ -25,7 +26,10 @@ public class MarkLogicExecuteErrorsProvider implements ErrorTypeProvider
     @Override
     public Set<ErrorTypeDefinition> getErrorTypes()
     {
-        HashSet<ErrorTypeDefinition> errors = new HashSet<>();
+        // sonarqube doesn't like this, but the Mulesoft interface requires Set<ErrorTypeDefinition> instead of
+        // Set<ErrorTypeDefinition<E extends Enum<E>>
+        @SuppressWarnings("java:S3740")
+        Set<ErrorTypeDefinition> errors = new HashSet<>();
         errors.add(MarkLogicConnectorSimpleErrorType.DATA_MOVEMENT_ERROR);
         return errors;
     }

--- a/src/main/java/com/marklogic/mule/extension/connector/internal/result/resultset/MarkLogicBinaryRecordExtractor.java
+++ b/src/main/java/com/marklogic/mule/extension/connector/internal/result/resultset/MarkLogicBinaryRecordExtractor.java
@@ -21,11 +21,8 @@ import com.marklogic.client.io.BytesHandle;
  */
 public class MarkLogicBinaryRecordExtractor extends MarkLogicRecordExtractor {
 
-    // Objects used for handling binary documents
-    private BytesHandle binaryHandle = new BytesHandle();
-
     @Override
-    protected Object extractRecord(DocumentRecord record) {
-        return record.getContent(binaryHandle).get();
+    protected Object extractRecord(DocumentRecord documentRecord) {
+        return documentRecord.getContent(new BytesHandle()).get();
     }
 }

--- a/src/main/java/com/marklogic/mule/extension/connector/internal/result/resultset/MarkLogicJSONRecordExtractor.java
+++ b/src/main/java/com/marklogic/mule/extension/connector/internal/result/resultset/MarkLogicJSONRecordExtractor.java
@@ -27,14 +27,12 @@ import java.util.Map;
  */
 public class MarkLogicJSONRecordExtractor extends MarkLogicRecordExtractor {
 
-    // Objects used for handling JSON documents
-    private JacksonHandle jacksonHandle = new JacksonHandle();
-    private ObjectMapper jsonMapper = new ObjectMapper();
+    private static ObjectMapper jsonMapper = new ObjectMapper();
 
     @Override
-    protected Object extractRecord(DocumentRecord record) {
+    protected Object extractRecord(DocumentRecord documentRecord) {
         Object content;
-        JsonNode jsonNode = record.getContent(jacksonHandle).get();
+        JsonNode jsonNode = documentRecord.getContent(new JacksonHandle()).get();
         JsonNodeType nodeType = jsonNode.getNodeType();
         if (null == nodeType) {
             content = jsonMapper.convertValue(jsonNode, Map.class);

--- a/src/main/java/com/marklogic/mule/extension/connector/internal/result/resultset/MarkLogicRecordExtractor.java
+++ b/src/main/java/com/marklogic/mule/extension/connector/internal/result/resultset/MarkLogicRecordExtractor.java
@@ -21,10 +21,9 @@ import com.marklogic.mule.extension.connector.api.operation.MarkLogicMimeType;
  */
 public abstract class MarkLogicRecordExtractor {
 
-    protected abstract Object extractRecord(DocumentRecord record);
+    protected abstract Object extractRecord(DocumentRecord documentRecord);
 
-    public static Object extractSingleRecord(DocumentRecord record) {
-        MarkLogicRecordExtractor re = MarkLogicMimeType.fromString(record.getMimetype()).getRecordExtractor();
-        return re.extractRecord(record);
+    public static Object extractSingleRecord(DocumentRecord documentRecord) {
+        return MarkLogicMimeType.fromString(documentRecord.getMimetype()).getRecordExtractor().extractRecord(documentRecord);
     }
 }

--- a/src/main/java/com/marklogic/mule/extension/connector/internal/result/resultset/MarkLogicTextRecordExtractor.java
+++ b/src/main/java/com/marklogic/mule/extension/connector/internal/result/resultset/MarkLogicTextRecordExtractor.java
@@ -21,13 +21,8 @@ import com.marklogic.client.io.StringHandle;
  */
 public class MarkLogicTextRecordExtractor extends MarkLogicRecordExtractor {
 
-    // Objects used for handling text documents
-    private StringHandle stringHandle = new StringHandle();
-
     @Override
-    protected Object extractRecord(DocumentRecord record) {
-        Object content;
-        content = record.getContent(stringHandle).get();
-        return content;
+    protected Object extractRecord(DocumentRecord documentRecord) {
+        return documentRecord.getContent(new StringHandle()).get();
     }
 }

--- a/src/main/java/com/marklogic/mule/extension/connector/internal/result/resultset/MarkLogicXMLRecordExtractor.java
+++ b/src/main/java/com/marklogic/mule/extension/connector/internal/result/resultset/MarkLogicXMLRecordExtractor.java
@@ -21,15 +21,9 @@ import com.marklogic.client.io.StringHandle;
  * Created by jkrebs on 1/19/2020.
  */
 public class MarkLogicXMLRecordExtractor extends MarkLogicRecordExtractor {
-    private final StringHandle handle;
-
-    public MarkLogicXMLRecordExtractor() {
-        this.handle = new StringHandle();
-    }
 
     @Override
-    protected Object extractRecord(DocumentRecord record) {
-        StringHandle retVal = record.getContent(handle).withMimetype("application/xml").withFormat(Format.XML);
-        return retVal.get();
+    protected Object extractRecord(DocumentRecord documentRecord) {
+        return documentRecord.getContent(new StringHandle()).withMimetype("application/xml").withFormat(Format.XML).get();
     }
 }

--- a/src/test/java/com/marklogic/mule/extension/connector/internal/config/MarkLogicConfigurationTest.java
+++ b/src/test/java/com/marklogic/mule/extension/connector/internal/config/MarkLogicConfigurationTest.java
@@ -174,19 +174,16 @@ public class MarkLogicConfigurationTest
         assertNotEquals(instance, instance.generateServerTransform("TestTransform", null));
     }
 
-    /**
-     * Test of createServerTransform method, of class MarkLogicConfiguration.
-     */
     @Test
     public void testGenerateServerTransformWithoutName()
     {
-        assertNull(instance.generateServerTransform(null, null));
+        assertFalse(instance.generateServerTransform(null, null).isPresent());
     }
 
     @Test
     public void testGenerateServerTransformNameWithoutParams()
     {
-        ServerTransform transform = instance.generateServerTransform("TestTransform", null);
+        ServerTransform transform = instance.generateServerTransform("TestTransform", null).get();
         assertEquals("TestTransform", transform.getName());
         assertEquals(0, transform.size());
     }
@@ -195,7 +192,7 @@ public class MarkLogicConfigurationTest
     public void testGenerateServerTransformConfigNameWithoutParams()
     {
         instance.setServerTransform("TestTransform");
-        ServerTransform transform = instance.generateServerTransform(null, null);
+        ServerTransform transform = instance.generateServerTransform(null, null).get();
         assertEquals("TestTransform", transform.getName());
         assertEquals(0, transform.size());
     }
@@ -204,7 +201,7 @@ public class MarkLogicConfigurationTest
     public void testGenerateServerTransformNameAndConfigNameWithoutParams()
     {
         instance.setServerTransform("TestTransform-Not-Used");
-        ServerTransform transform = instance.generateServerTransform("TestTransform", null);
+        ServerTransform transform = instance.generateServerTransform("TestTransform", null).get();
         assertEquals("TestTransform", transform.getName());
         assertEquals(0, transform.size());
     }
@@ -212,7 +209,7 @@ public class MarkLogicConfigurationTest
     @Test
     public void testGenerateServerTransformWithEmptyParams()
     {
-        ServerTransform transform = instance.generateServerTransform("TestTransform", "   ");
+        ServerTransform transform = instance.generateServerTransform("TestTransform", "   ").get();
         assertEquals("TestTransform", transform.getName());
         assertEquals(0, transform.size());
     }
@@ -222,7 +219,7 @@ public class MarkLogicConfigurationTest
     {
         instance.setServerTransform("TestTransform");
         instance.setServerTransformParams("null");
-        ServerTransform transform = instance.generateServerTransform(null, "not-used");
+        ServerTransform transform = instance.generateServerTransform(null, "not-used").get();
         assertEquals("TestTransform", transform.getName());
         assertEquals(0, transform.size());
     }
@@ -256,14 +253,14 @@ public class MarkLogicConfigurationTest
         ServerTransform transform;
         if(useVars)
         {
-            transform = instance.generateServerTransform(name, params);
+            transform = instance.generateServerTransform(name, params).get();
         }
         else
         {
             instance.setServerTransform(name);
             instance.setServerTransformParams(params);
             
-            transform = instance.generateServerTransform(null, null);
+            transform = instance.generateServerTransform(null, null).get();
         }
         
         assertEquals(name, transform.getName());

--- a/src/test/java/com/marklogic/mule/extension/connector/internal/connection/MarkLogicConnectionTest.java
+++ b/src/test/java/com/marklogic/mule/extension/connector/internal/connection/MarkLogicConnectionTest.java
@@ -21,7 +21,6 @@ import com.marklogic.client.DatabaseClientFactory.BasicAuthContext;
 import com.marklogic.client.DatabaseClientFactory.CertificateAuthContext;
 import com.marklogic.client.DatabaseClientFactory.DigestAuthContext;
 import com.marklogic.mule.extension.connector.internal.operation.MarkLogicConnectionInvalidationListener;
-import org.junit.Ignore;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.mule.runtime.api.lifecycle.CreateException;

--- a/src/test/java/com/marklogic/mule/extension/connector/internal/operation/MarkLogicOperationTest.java
+++ b/src/test/java/com/marklogic/mule/extension/connector/internal/operation/MarkLogicOperationTest.java
@@ -30,9 +30,7 @@ import com.marklogic.mule.extension.connector.internal.config.MarkLogicConfigura
 import com.marklogic.mule.extension.connector.internal.connection.MarkLogicConnection;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.mule.runtime.extension.api.runtime.streaming.PagingProvider;


### PR DESCRIPTION
This leaves 11 warnings (according to sonarqube 9.8.0.63668), most of which deal with too many arguments. 

One note about the RecordExtractor classes - I modified those to not reuse a Handle class, as I don't believe any of those are guaranteed to be thread-safe. 